### PR TITLE
Disqus Shortname bugfix

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -48,7 +48,7 @@
       </div>
 
 
-      {{ if .Site.DisqusShortname }}
+      {{ if .Site.Config.Services.Disqus.Shortname }}
       <div class="col-lg-8" data-aos="fade-in">
         <!-- comments -->
         <div class="mt-5">


### PR DESCRIPTION
The theme as installed actually points to a previous commit where the errors related to partial executions don't happen.

These errors are manifested by the favicon problem, but there are several other partials that are called and cannot execute.

I looked for where this specific commit was specified but could not find it.

This may be to the fact that the theme is actually a template of a paying theme, and according to their logs they have been maintaining the pro version, but the free template less so.

So I refixed the Disqus Shortname bug from the commit that actually renders the site when installed.

If needed we will re-fork from the parent repo in the future.